### PR TITLE
Fixed TTdrFile::Open to set library specific classes

### DIFF
--- a/libraries/TTdr/TTdrFile.cxx
+++ b/libraries/TTdr/TTdrFile.cxx
@@ -19,7 +19,8 @@
 #include "TTdrEvent.h"
 #include "TRunInfo.h"
 #include "TTdrDetectorInformation.h"
-#include "GVersion.h"
+#include "TTdrMnemonic.h"
+#include "iThembaDataVersion.h"
 
 /// \cond CLASSIMP
 ClassImp(TTdrFile)
@@ -81,9 +82,12 @@ bool TTdrFile::Open(const char* filename)
 #define O_LARGEFILE 0
 #endif
 
+	// setup TChannel to use our mnemonics
+	TChannel::SetMnemonicClass(TTdrMnemonic::Class());
+
    TRunInfo::SetRunInfo(GetRunNumber(), GetSubRunNumber());
 	TRunInfo::ClearVersion();
-   TRunInfo::SetVersion(GRSI_RELEASE);
+   TRunInfo::SetVersion(ITHEMBADATA_RELEASE);
 
    std::cout<<"Successfully opened file with "<<fFileSize<<" bytes!"<<std::endl;
 

--- a/libraries/TTdr/TTdrFile.cxx
+++ b/libraries/TTdr/TTdrFile.cxx
@@ -18,6 +18,7 @@
 #include "TTdrFile.h"
 #include "TTdrEvent.h"
 #include "TRunInfo.h"
+#include "TTdrDetectorInformation.h"
 #include "GVersion.h"
 
 /// \cond CLASSIMP
@@ -92,6 +93,9 @@ bool TTdrFile::Open(const char* filename)
 	//	if(i%16 == 15) std::cout<<std::endl;
 	//}
 	//std::cout<<std::dec<<std::setfill(' ');
+
+	TTdrDetectorInformation* detInfo = new TTdrDetectorInformation();
+	TRunInfo::SetDetectorInformation(detInfo);
 
    return true;
 }


### PR DESCRIPTION
- sets the detector information to the TTdrDetectorInformation, and
- sets the mnemonic class to be TTdrMnemonic