### PR TITLE
Removed std::move for simple pointers

### DIFF
--- a/libraries/TTdrAnalysis/TTdrClover/TTdrClover.cxx
+++ b/libraries/TTdrAnalysis/TTdrClover/TTdrClover.cxx
@@ -363,8 +363,8 @@ void TTdrClover::AddFragment(const std::shared_ptr<const TFragment>& frag, TChan
 		return;
 	}
 
-	auto geHit = new TTdrCloverHit(*frag);
-	fHits.push_back(std::move(geHit));
+	auto hit = new TTdrCloverHit(*frag);
+	fHits.push_back(hit);
 }
 
 TVector3 TTdrClover::GetPosition(int DetNbr, int CryNbr, double dist)

--- a/libraries/TTdrAnalysis/TTdrPlastic/TTdrPlastic.cxx
+++ b/libraries/TTdrAnalysis/TTdrPlastic/TTdrPlastic.cxx
@@ -73,8 +73,8 @@ TTdrPlastic& TTdrPlastic::operator=(const TTdrPlastic& rhs)
 
 void TTdrPlastic::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
-	auto scHit = new TTdrPlasticHit(*frag);                 // Construction of TTdrPlasticHit is handled in the constructor
-	fHits.push_back(std::move(scHit)); // Can't use scHit outside of vector after using std::move
+	auto hit = new TTdrPlasticHit(*frag);                 // Construction of TTdrPlasticHit is handled in the constructor
+	fHits.push_back(hit);
 }
 
 void TTdrPlastic::Print(Option_t*) const

--- a/libraries/TTdrAnalysis/TTdrSiLi/TTdrSiLi.cxx
+++ b/libraries/TTdrAnalysis/TTdrSiLi/TTdrSiLi.cxx
@@ -67,7 +67,7 @@ TTdrSiLi& TTdrSiLi::operator=(const TTdrSiLi& rhs)
 void TTdrSiLi::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
 	auto hit = new TTdrSiLiHit(*frag);
-	fHits.push_back(std::move(hit));
+	fHits.push_back(hit);
 }
 
 TVector3 TTdrSiLi::GetPosition(int)

--- a/libraries/TTdrAnalysis/TTdrTigress/TTdrTigress.cxx
+++ b/libraries/TTdrAnalysis/TTdrTigress/TTdrTigress.cxx
@@ -363,8 +363,8 @@ void TTdrTigress::AddFragment(const std::shared_ptr<const TFragment>& frag, TCha
 		return;
 	}
 
-	auto geHit = new TTdrTigressHit(*frag);
-	fHits.push_back(std::move(geHit));
+	auto hit = new TTdrTigressHit(*frag);
+	fHits.push_back(hit);
 }
 
 TVector3 TTdrTigress::GetPosition(int DetNbr, int CryNbr, double dist)


### PR DESCRIPTION
See GRIFFINCollaboration/GRSISort#1196.