### PR TITLE
Only setting -std if not set by root-config, see GRIFFINCollaboration/GRSISort#1195

### DIFF
--- a/util/config
+++ b/util/config
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash 
+
+readlink=readlink
+if [ `uname` = "AIX" ]; then
+  readlink=echo
+fi
+
+# work around readlink versions not having -f option
+fullpath1=`$readlink $0`
+if [ "$?" -ne "0" ]; then
+  fullpath1=$0
+else
+  if [ ${fullpath1##/} = $fullpath1 ] && [ ${fullpath1##~} = $fullpath1 ]; then
+    # relative path, prepend directory where executable was found
+    lpath=`dirname $0`
+    fullpath1=$lpath/$fullpath1
+  fi
+fi
+
+progdir=`dirname $fullpath1`
+runningdir=`pwd`
+if [ ${progdir##/} != $progdir ] || [ ${progdir##~} != $progdir ]; then
+  # absolute path
+  fullpath=$progdir
+else
+  # relative path
+  if [ $progdir != "." ]; then
+    fullpath=$runningdir/$progdir
+  else
+    fullpath=$runningdir
+  fi
+fi
+
+# work around readlink versions not having -f option
+fullpath1=`$readlink $fullpath`
+if [ "$?" -ne "0" ]; then
+  fullpath1=$fullpath
+fi
+
+
+libdir=$GRSISYS/iThembaData/lib
+incdir=$GRSISYS/iThembaData/include
+
+libs="-lTTdrClover -lTTdrDetector -lTTdrPlastic -lTTdrSiLi -lTTdrTigress"
+
+if [[ $(root-config --cflags) == *"-std="* ]]
+then
+	cflags="-I$incdir"
+else
+	cflags="-std=c++11 -I$incdir"
+fi
+
+usage="\
+Usage: grsi-config [--version] [--incdir] [--cflags] [--libs] [--help]"
+
+if test $# -eq 0; then
+  echo "${usage}" 1>&2
+  exit 1
+fi
+
+out=""
+
+incdirout=no
+cflagsout=no
+libsout=no
+
+while test $# -gt 0; do
+  case "$1" in 
+  -*=*) optarg=`echo "$1" | sed 's/[-_a-zA-Z0-9]*=//'` ;;
+  *)    optarg= ;;
+  esac
+
+  case $1 in
+    --version)
+      ### Output the version number.  If GVersion.h can not be found, give up.
+      if test -r ${incdir}/GVersion.h; then
+        out="$out `sed -n 's,.*GRSI_RELEASE *\"\(.*\)\".*,\1,p' < ${incdir}/GVersion.h`"
+      else
+        echo "cannot read ${incdir}/GVersion.h"
+        exit 1
+      fi
+      ;;
+    --incdir)
+      if test "x$incdirout" = "xyes" ; then
+        shift
+        continue
+      fi
+      incdirout="yes"
+      out="$out $incdir "
+      ;;
+    --cflags)
+      if test "x$cflagsout" = "xyes" ; then
+        shift
+        continue
+      fi
+      cflagsout="yes"
+      out="$out $cflags "
+      ;;
+    --libs)
+      if test "x$libsout" = "xyes" ; then
+        shift
+        continue
+      fi
+      libsout="yes"
+      out=$"$out -L${libdir} $libs "
+      ;;
+    --help)
+      ### Print a helpful message...
+      echo "Usage: `basename $0` [options]"
+      echo ""
+      echo "  --version       Print the current GRSI Version number."
+      echo "  --incdir        Print header path."
+      echo "  --cflags        Print compiler flags and header path."
+      echo "  --libs          Print libdir + libraries."
+      echo "  --help          Print what you see here."
+      exit 0
+      ;;
+    *)
+      ### Give an error
+      echo "Unknown argument \"$1\"!" 1>&2
+      echo "${usage}" 1>&2
+      exit 1
+      ;;
+   esac
+   shift 
+done
+
+echo $out
+


### PR DESCRIPTION
Also adding the util/config file as was done for the other data parser libraries