### PR TITLE
Cosmetic changes

### DIFF
--- a/include/TTdrClover.h
+++ b/include/TTdrClover.h
@@ -123,6 +123,7 @@ public:
    void Copy(TObject&) const override;            //!<!
    void Clear(Option_t* opt = "all") override;    //!<!
    void Print(Option_t* opt = "") const override; //!<!
+	void Print(std::ostream& out) const override;
 
    /// \cond CLASSIMP
    ClassDefOverride(TTdrClover, 1) // TdrClover Physics structure

--- a/include/TTdrCloverHit.h
+++ b/include/TTdrCloverHit.h
@@ -72,6 +72,7 @@ public:
 public:
    void Clear(Option_t* opt = "") override;       //!<!
    void Print(Option_t* opt = "") const override; //!<!
+	void Print(std::ostream& out) const override;
    void Copy(TObject&) const override;            //!<!
    void Copy(TObject&, bool) const override;      //!<!
 

--- a/include/TTdrPlastic.h
+++ b/include/TTdrPlastic.h
@@ -52,6 +52,7 @@ private:
 public:
    void Clear(Option_t* opt = "") override;       //!<!
    void Print(Option_t* opt = "") const override; //!<!
+	void Print(std::ostream& out) const override;
 
    /// \cond CLASSIMP
    ClassDefOverride(TTdrPlastic, 2) // TdrPlastic Physics structure

--- a/include/TTdrPlasticHit.h
+++ b/include/TTdrPlasticHit.h
@@ -50,6 +50,7 @@ public:
 public:
    void Clear(Option_t* opt = "") override;       //!<!
    void Print(Option_t* opt = "") const override; //!<!
+	void Print(std::ostream& out) const override;
    void Copy(TObject&) const override;            //!<!
    void Copy(TObject&, bool) const override;      //!<!
 

--- a/include/TTdrSiLi.h
+++ b/include/TTdrSiLi.h
@@ -41,6 +41,7 @@ public:
    void Copy(TObject&) const override;            //!<!
    void Clear(Option_t* opt = "all") override;    //!<!
    void Print(Option_t* opt = "") const override; //!<!
+	void Print(std::ostream& out) const override;
 
    /// \cond CLASSIMP
    ClassDefOverride(TTdrSiLi, 4) // TdrSiLi Physics structure

--- a/include/TTdrSiLiHit.h
+++ b/include/TTdrSiLiHit.h
@@ -39,6 +39,7 @@ public:
 public:
    void Clear(Option_t* opt = "") override;            //!<!
    void Print(Option_t* opt = "") const override;      //!<!
+	void Print(std::ostream& out) const override;
    void     Copy(TObject&) const override;             //!<!
    TVector3 GetPosition(Double_t dist) const override; //!<!
    TVector3 GetPosition() const override;              //!<!

--- a/include/TTdrTigress.h
+++ b/include/TTdrTigress.h
@@ -124,6 +124,7 @@ public:
    void Copy(TObject&) const override;            //!<!
    void Clear(Option_t* opt = "all") override;    //!<!
    void Print(Option_t* opt = "") const override; //!<!
+	void Print(std::ostream& out) const override;
 
    /// \cond CLASSIMP
    ClassDefOverride(TTdrTigress, 1) // TdrTigress Physics structure

--- a/include/TTdrTigressHit.h
+++ b/include/TTdrTigressHit.h
@@ -74,6 +74,7 @@ public:
 public:
    void Clear(Option_t* opt = "") override;       //!<!
    void Print(Option_t* opt = "") const override; //!<!
+	void Print(std::ostream& out) const override;
    void Copy(TObject&) const override;            //!<!
    void Copy(TObject&, bool) const override;      //!<!
 

--- a/libraries/TTdrAnalysis/TTdrClover/TTdrClover.cxx
+++ b/libraries/TTdrAnalysis/TTdrClover/TTdrClover.cxx
@@ -11,15 +11,15 @@
 
 #include "TGRSIOptions.h"
 
-////////////////////////////////////////////////////////////
-//
-// TTdrClover
-//
-// The TTdrClover class defines the observables and algorithms used
-// when analyzing GRIFFIN data. It includes detector positions,
-// add-back methods, etc.
-//
-////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+///
+/// TTdrClover
+///
+/// The TTdrClover class defines the observables and algorithms used
+/// when analyzing GRIFFIN data. It includes detector positions,
+/// add-back methods, etc.
+///
+/////////////////////////////////////////////////////////////
 
 /// \cond CLASSIMP
 ClassImp(TTdrClover)
@@ -168,28 +168,35 @@ void TTdrClover::Clear(Option_t* opt)
 
 void TTdrClover::Print(Option_t*) const
 {
-   std::cout<<"TdrClover Contains: "<<std::endl;
-   std::cout<<std::setw(6)<<GetMultiplicity()<<" hits"<<std::endl;
+	Print(std::cout);
+}
+
+void TTdrClover::Print(std::ostream& out) const
+{
+	std::ostringstream str;
+   str<<"TdrClover Contains: "<<std::endl;
+   str<<std::setw(6)<<GetMultiplicity()<<" hits"<<std::endl;
 
    if(IsAddbackSet()) {
-      std::cout<<std::setw(6)<<fAddbackHits.size()<<" addback hits"<<std::endl;
+      str<<std::setw(6)<<fAddbackHits.size()<<" addback hits"<<std::endl;
    } else {
-      std::cout<<std::setw(6)<<" "<<" Addback not set"<<std::endl;
+      str<<std::setw(6)<<" "<<" Addback not set"<<std::endl;
    }
 
    if(IsSuppressedSet()) {
-      std::cout<<std::setw(6)<<fSuppressedHits.size()<<" suppressed hits"<<std::endl;
+      str<<std::setw(6)<<fSuppressedHits.size()<<" suppressed hits"<<std::endl;
    } else {
-      std::cout<<std::setw(6)<<" "<<" suppressed not set"<<std::endl;
+      str<<std::setw(6)<<" "<<" suppressed not set"<<std::endl;
    }
 
    if(IsSuppressedAddbackSet()) {
-      std::cout<<std::setw(6)<<fSuppressedAddbackHits.size()<<" suppressed addback hits"<<std::endl;
+      str<<std::setw(6)<<fSuppressedAddbackHits.size()<<" suppressed addback hits"<<std::endl;
    } else {
-      std::cout<<std::setw(6)<<" "<<" suppressed Addback not set"<<std::endl;
+      str<<std::setw(6)<<" "<<" suppressed Addback not set"<<std::endl;
    }
 
-   std::cout<<std::setw(6)<<fCycleStart<<" cycle start"<<std::endl;
+   str<<std::setw(6)<<fCycleStart<<" cycle start"<<std::endl;
+	out<<str.str();
 }
 
 TTdrClover& TTdrClover::operator=(const TTdrClover& rhs)

--- a/libraries/TTdrAnalysis/TTdrClover/TTdrClover.cxx
+++ b/libraries/TTdrAnalysis/TTdrClover/TTdrClover.cxx
@@ -117,7 +117,7 @@ std::map<int, TSpline*> TTdrClover::fEnergyResiduals;
 TTdrClover::TTdrClover() : TSuppressed()
 {
 // Default ctor. Ignores TObjectStreamer in ROOT < 6
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
    Clear();
@@ -126,7 +126,7 @@ TTdrClover::TTdrClover() : TSuppressed()
 TTdrClover::TTdrClover(const TTdrClover& rhs) : TSuppressed()
 {
 // Copy ctor. Ignores TObjectStreamer in ROOT < 6
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
    rhs.Copy(*this);

--- a/libraries/TTdrAnalysis/TTdrClover/TTdrCloverHit.cxx
+++ b/libraries/TTdrAnalysis/TTdrClover/TTdrCloverHit.cxx
@@ -71,12 +71,18 @@ void TTdrCloverHit::Clear(Option_t* opt)
 void TTdrCloverHit::Print(Option_t*) const
 {
    // Prints the Detector Number, Crystal Number, Energy, Time and Angle.
-   printf("TdrClover Detector: %i\n", GetDetector());
-   printf("TdrClover Crystal:  %i\n", GetCrystal());
-   printf("TdrClover Energy:   %lf\n", GetEnergy());
-   printf("TdrClover hit time:   %lf\n", GetTime());
-   printf("TdrClover hit TV3 theta: %.2f\tphi%.2f\n", GetPosition().Theta() * 180 / (3.141597),
-          GetPosition().Phi() * 180 / (3.141597));
+	Print(std::cout);
+}
+
+void TTdrCloverHit::Print(std::ostream& out) const
+{
+	std::ostringstream str;
+   str<<"TdrClover Detector: "<<GetDetector()<<std::endl;
+   str<<"TdrClover Crystal:  "<<GetCrystal()<<std::endl;
+   str<<"TdrClover Energy:   "<<GetEnergy()<<std::endl;
+   str<<"TdrClover hit time: "<<GetTime()<<std::endl;
+   str<<"TdrClover hit TV3 theta: "<<GetPosition().Theta() * 180./3.141597<<"\tphi"<<GetPosition().Phi() * 180./3.141597<<std::endl;
+	out<<str.str();
 }
 
 TVector3 TTdrCloverHit::GetPosition(double dist) const

--- a/libraries/TTdrAnalysis/TTdrClover/TTdrCloverHit.cxx
+++ b/libraries/TTdrAnalysis/TTdrClover/TTdrCloverHit.cxx
@@ -13,7 +13,7 @@ TTdrCloverHit::TTdrCloverHit()
    : TDetectorHit()
 {
 // Default Ctor. Ignores TObject Streamer in ROOT < 6.
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
    Clear();

--- a/libraries/TTdrAnalysis/TTdrPlastic/TTdrPlastic.cxx
+++ b/libraries/TTdrAnalysis/TTdrPlastic/TTdrPlastic.cxx
@@ -80,6 +80,13 @@ void TTdrPlastic::AddFragment(const std::shared_ptr<const TFragment>& frag, TCha
 void TTdrPlastic::Print(Option_t*) const
 {
 	// Prints out TTdrPlastic Multiplicity, currently does little.
-	printf("%lu fHits\n", fHits.size());
+	Print(std::cout);
+}
+
+void TTdrPlastic::Print(std::ostream& out) const
+{
+	std::ostringstream str;
+	str<<fHits.size()<<" fHits"<<std::endl;
+	out<<str.str();
 }
 

--- a/libraries/TTdrAnalysis/TTdrPlastic/TTdrPlastic.cxx
+++ b/libraries/TTdrAnalysis/TTdrPlastic/TTdrPlastic.cxx
@@ -36,7 +36,7 @@ TVector3 TTdrPlastic::gPaddlePosition[21] = {
 TTdrPlastic::TTdrPlastic()
 {
 	// Default Constructor
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
 	// Class()->AddRule("TTdrPlastic sceptar_hits attributes=NotOwner");
@@ -52,7 +52,7 @@ TTdrPlastic::~TTdrPlastic()
 TTdrPlastic::TTdrPlastic(const TTdrPlastic& rhs) : TDetector()
 {
 	// Copy Contructor
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
 	rhs.Copy(*this);

--- a/libraries/TTdrAnalysis/TTdrPlastic/TTdrPlasticHit.cxx
+++ b/libraries/TTdrAnalysis/TTdrPlastic/TTdrPlasticHit.cxx
@@ -119,8 +119,15 @@ void TTdrPlasticHit::Print(Option_t*) const
 	// Detector
 	// Energy
 	// Time
-	printf("TdrPlastic Detector: %i\n", GetDetector());
-	printf("TdrPlastic hit energy: %.2f\n", GetEnergy());
-	printf("TdrPlastic hit time:   %.lf\n", GetTime());
+	Print(std::cout);
+}
+
+void TTdrPlasticHit::Print(std::ostream& out) const
+{
+	std::ostringstream str;
+	str<<"TdrPlastic Detector:   "<<GetDetector()<<std::endl;
+	str<<"TdrPlastic hit energy: "<<GetEnergy()<<std::endl;
+	str<<"TdrPlastic hit time:   "<<GetTime()<<std::endl;
+	out<<str.str();
 }
 

--- a/libraries/TTdrAnalysis/TTdrPlastic/TTdrPlasticHit.cxx
+++ b/libraries/TTdrAnalysis/TTdrPlastic/TTdrPlasticHit.cxx
@@ -15,7 +15,7 @@ ClassImp(TTdrPlasticHit)
 TTdrPlasticHit::TTdrPlasticHit()
 {
 	// Default Constructor
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
 	Clear();
@@ -26,7 +26,7 @@ TTdrPlasticHit::~TTdrPlasticHit() = default;
 TTdrPlasticHit::TTdrPlasticHit(const TTdrPlasticHit& rhs) : TDetectorHit()
 {
 	// Copy Constructor
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
 	Clear();

--- a/libraries/TTdrAnalysis/TTdrSiLi/TTdrSiLi.cxx
+++ b/libraries/TTdrAnalysis/TTdrSiLi/TTdrSiLi.cxx
@@ -55,7 +55,14 @@ void TTdrSiLi::Clear(Option_t* opt)
 void TTdrSiLi::Print(Option_t*) const
 {
 	// Prints out TTdrSiLi members, currently does nothing.
-	printf("%lu fHits\n", fHits.size());
+	Print(std::cout);
+}
+
+void TTdrSiLi::Print(std::ostream& out) const
+{
+	std::ostringstream str;
+	str<<fHits.size()<<" fHits"<<std::endl;
+	out<<str.str();
 }
 
 TTdrSiLi& TTdrSiLi::operator=(const TTdrSiLi& rhs)

--- a/libraries/TTdrAnalysis/TTdrSiLi/TTdrSiLi.cxx
+++ b/libraries/TTdrAnalysis/TTdrSiLi/TTdrSiLi.cxx
@@ -20,7 +20,7 @@ bool TTdrSiLi::fSetCoreWave = false;
 
 TTdrSiLi::TTdrSiLi() : TDetector()
 {
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
 	Clear();
@@ -28,7 +28,7 @@ TTdrSiLi::TTdrSiLi() : TDetector()
 
 TTdrSiLi::TTdrSiLi(const TTdrSiLi& rhs) : TDetector()
 {
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
 	rhs.Copy(*this);

--- a/libraries/TTdrAnalysis/TTdrSiLi/TTdrSiLiHit.cxx
+++ b/libraries/TTdrAnalysis/TTdrSiLi/TTdrSiLiHit.cxx
@@ -47,9 +47,16 @@ void TTdrSiLiHit::Clear(Option_t* opt)
 
 void TTdrSiLiHit::Print(Option_t*) const
 {
-   printf("TdrSiLi Detector: %i\n", GetDetector());
-   printf("TdrSiLi Energy:   %lf\n", GetEnergy());
-   printf("TdrSiLi hit time:   %f\n", GetTime());
+	Print(std::cout);
+}
+
+void TTdrSiLiHit::Print(std::ostream& out) const
+{
+	std::ostringstream str;
+   str<<"TdrSiLi Detector: "<<GetDetector()<<std::endl;
+   str<<"TdrSiLi Energy:   "<<GetEnergy()<<std::endl;
+   str<<"TdrSiLi hit time: "<<GetTime()<<std::endl;
+	out<<str.str();
 }
 
 TVector3 TTdrSiLiHit::GetPosition(Double_t) const

--- a/libraries/TTdrAnalysis/TTdrSiLi/TTdrSiLiHit.cxx
+++ b/libraries/TTdrAnalysis/TTdrSiLi/TTdrSiLiHit.cxx
@@ -9,7 +9,7 @@ ClassImp(TTdrSiLiHit)
 TTdrSiLiHit::TTdrSiLiHit()
    : TDetectorHit()
 {
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
    Clear();
@@ -17,7 +17,7 @@ TTdrSiLiHit::TTdrSiLiHit()
 
 TTdrSiLiHit::TTdrSiLiHit(const TTdrSiLiHit& rhs) : TDetectorHit()
 {
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
    Clear();

--- a/libraries/TTdrAnalysis/TTdrTigress/TTdrTigress.cxx
+++ b/libraries/TTdrAnalysis/TTdrTigress/TTdrTigress.cxx
@@ -118,7 +118,7 @@ std::map<int, TSpline*> TTdrTigress::fEnergyResiduals;
 TTdrTigress::TTdrTigress() : TSuppressed()
 {
 // Default ctor. Ignores TObjectStreamer in ROOT < 6
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
    Clear();
@@ -127,7 +127,7 @@ TTdrTigress::TTdrTigress() : TSuppressed()
 TTdrTigress::TTdrTigress(const TTdrTigress& rhs) : TSuppressed()
 {
 // Copy ctor. Ignores TObjectStreamer in ROOT < 6
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
    rhs.Copy(*this);

--- a/libraries/TTdrAnalysis/TTdrTigress/TTdrTigress.cxx
+++ b/libraries/TTdrAnalysis/TTdrTigress/TTdrTigress.cxx
@@ -168,29 +168,35 @@ void TTdrTigress::Clear(Option_t* opt)
 
 void TTdrTigress::Print(Option_t*) const
 {
-   std::cout<<"TdrTigress Contains: "<<std::endl;
-   std::cout<<std::setw(6)<<GetMultiplicity()<<" hits"<<std::endl;
+	Print(std::cout);
+}
+
+void TTdrTigress::Print(std::ostream& out) const
+{
+	std::ostringstream str;
+   str<<"TdrTigress Contains: "<<std::endl;
+   str<<std::setw(6)<<GetMultiplicity()<<" hits"<<std::endl;
 
    if(IsAddbackSet()) {
-      std::cout<<std::setw(6)<<fAddbackHits.size()<<" addback hits"<<std::endl;
+      str<<std::setw(6)<<fAddbackHits.size()<<" addback hits"<<std::endl;
    } else {
-      std::cout<<std::setw(6)<<" "
-               <<" Addback not set"<<std::endl;
+      str<<std::setw(6)<<" "<<" Addback not set"<<std::endl;
    }
 
    if(IsSuppressedSet()) {
-      std::cout<<std::setw(6)<<fSuppressedHits.size()<<" suppressed hits"<<std::endl;
+      str<<std::setw(6)<<fSuppressedHits.size()<<" suppressed hits"<<std::endl;
    } else {
-      std::cout<<std::setw(6)<<" "<<" suppressed not set"<<std::endl;
+      str<<std::setw(6)<<" "<<" suppressed not set"<<std::endl;
    }
 
    if(IsSuppressedAddbackSet()) {
-      std::cout<<std::setw(6)<<fSuppressedAddbackHits.size()<<" suppressed addback hits"<<std::endl;
+      str<<std::setw(6)<<fSuppressedAddbackHits.size()<<" suppressed addback hits"<<std::endl;
    } else {
-      std::cout<<std::setw(6)<<" "<<" suppressed Addback not set"<<std::endl;
+      str<<std::setw(6)<<" "<<" suppressed Addback not set"<<std::endl;
    }
 
-   std::cout<<std::setw(6)<<fCycleStart<<" cycle start"<<std::endl;
+   str<<std::setw(6)<<fCycleStart<<" cycle start"<<std::endl;
+	out<<str.str();
 }
 
 TTdrTigress& TTdrTigress::operator=(const TTdrTigress& rhs)

--- a/libraries/TTdrAnalysis/TTdrTigress/TTdrTigressHit.cxx
+++ b/libraries/TTdrAnalysis/TTdrTigress/TTdrTigressHit.cxx
@@ -71,12 +71,18 @@ void TTdrTigressHit::Clear(Option_t* opt)
 void TTdrTigressHit::Print(Option_t*) const
 {
    // Prints the Detector Number, Crystal Number, Energy, Time and Angle.
-   printf("TdrTigress Detector: %i\n", GetDetector());
-   printf("TdrTigress Crystal:  %i\n", GetCrystal());
-   printf("TdrTigress Energy:   %lf\n", GetEnergy());
-   printf("TdrTigress hit time:   %lf\n", GetTime());
-   printf("TdrTigress hit TV3 theta: %.2f\tphi%.2f\n", GetPosition().Theta() * 180 / (3.141597),
-          GetPosition().Phi() * 180 / (3.141597));
+	Print(std::cout);
+}
+
+void TTdrTigressHit::Print(std::ostream& out) const
+{
+	std::ostringstream str;
+   str<<"TdrTigress Detector: "<<GetDetector()<<std::endl;
+   str<<"TdrTigress Crystal:  "<<GetCrystal()<<std::endl;
+   str<<"TdrTigress Energy:   "<<GetEnergy()<<std::endl;
+   str<<"TdrTigress hit time: "<<GetTime()<<std::endl;
+   str<<"TdrTigress hit TV3 theta: "<<GetPosition().Theta() * 180./3.141597<<"\tphi"<<GetPosition().Phi() * 180./3.141597<<std::endl;
+	out<<str.str();
 }
 
 TVector3 TTdrTigressHit::GetPosition(double dist) const

--- a/libraries/TTdrAnalysis/TTdrTigress/TTdrTigressHit.cxx
+++ b/libraries/TTdrAnalysis/TTdrTigress/TTdrTigressHit.cxx
@@ -13,7 +13,7 @@ TTdrTigressHit::TTdrTigressHit()
    : TDetectorHit()
 {
 // Default Ctor. Ignores TObject Streamer in ROOT < 6.
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
    Clear();

--- a/makefile
+++ b/makefile
@@ -15,8 +15,6 @@ SRC_SUFFIX = cxx
 
 # EVERYTHING PAST HERE SHOULD WORK AUTOMATICALLY
 
-MAJOR_ROOT_VERSION:=$(shell root-config --version | cut -d '.' -f1)
-MINOR_ROOT_VERSION:=$(shell root-config --version | cut -d '.' -f2 | cut -d '/' -f1)
 ROOT_PYTHON_VERSION=$(shell root-config --python-version)
 
 MATHMORE_INSTALLED:=$(shell root-config --has-mathmore)
@@ -32,7 +30,6 @@ lib_o_files     = $(patsubst %.$(SRC_SUFFIX),.build/%.o,$(call lib_src_files,$(1
 lib_linkdef     = $(wildcard $(call libdir,$(1))/LinkDef.h)
 lib_dictionary  = $(patsubst %/LinkDef.h,.build/%/LibDictionary.o,$(call lib_linkdef,$(1)))
 	
-CFLAGS += -DMAJOR_ROOT_VERSION=${MAJOR_ROOT_VERSION}
 ifeq ($(ROOT_PYTHON_VERSION),2.7)
   CFLAGS += -DHAS_CORRECT_PYTHON_VERSION
 endif


### PR DESCRIPTION
- Replaced MAJOR_ROOT_VERSION with ROOT_VERSION_CODE.
- Overloaded the Print(std::ostream&) function for detector and detector hit classes for threadsafe printing with the streaming operator.